### PR TITLE
DNS Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,41 @@ Example
 [OK] 200 OK
 ```
 
+#### `net add-dns`
+Add a DNS server to your gateway.
+
+Usage: `net add-dns <dns-ip>`
+
+Example
+```
+> net add-dns 8.8.8.8
+[OK] 200 OK
+```
+
+#### `net delete-dns`
+Delete a DNS server from your gateway.
+
+Usage: `net delete-dns <dns-ip>`
+
+Example
+```
+> net delete-dns 8.8.8.4
+[OK] 200 OK
+```
+
+#### `net get-dns`
+Get the DNS servers used by your gateway for name resolution.
+
+Usage: `net get-dns`
+
+Example
+```
+> net get-dns
+targets:
+[0]: "8.8.8.8"[1]: "8.8.8.4"
+
+```
+
 
 # Developing Maestro-Shell
 

--- a/shell/client.go
+++ b/shell/client.go
@@ -392,7 +392,7 @@ func (self *MaestroClient) GetDNS() (out string, err error) {
 		DebugOut("resp.Body body = %+v", body)
 		DebugOut("resp.Body body = %s", string(body))
 		if err2 == nil {
-			buf.WriteString("targets:")
+			buf.WriteString("nameservers:")
 			out, err = FormatJsonEasyRead(buf, body)
 		} else {
 			DebugOut("Error on ReadAll %s", err2.Error())


### PR DESCRIPTION
DNS Docs and status

Adding documentation for the new DNS commands: add-dns,
get-dns, and delete-dns.

Also fixing a status message that had the wrong label in
get-dns.